### PR TITLE
Add JSON comment stripping utility

### DIFF
--- a/pages_no_comment.json
+++ b/pages_no_comment.json
@@ -2,7 +2,7 @@
 	"easycom": {
 		"^u-(.*)": "@/uview-ui/components/u-$1/u-$1.vue"
 	},
-	"pages": [ //pages数组中第一项表示应用启动页，参考：https://uniapp.dcloud.io/collocation/pages
+	"pages": [
 		{
 			"path": "pages/index/tabbar",
 			"style": {
@@ -294,13 +294,13 @@
 						"navigationBarTitleText": "在线选座"
 					}
 				},
-				// {
-				// 	"path": "loveChina",
-				// 	"style": {
-				// 		"navigationStyle": "custom",
-				// 		"navigationBarTitleText": "国庆头像"
-				// 	}
-				// },
+
+
+
+
+
+
+
 				{
 					"path": "chat/chat",
 					"style": {
@@ -409,7 +409,7 @@
 						"navigationStyle": "custom"
 					}
 				},
-				// 临时工单
+
 				{
 					"path": "workOrder/index",
 					"style" : {

--- a/strip_comments.js
+++ b/strip_comments.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const input = process.argv[2] || 'pages.json';
+const output = process.argv[3] || 'pages_no_comment.json';
+let lines = fs.readFileSync(input, 'utf8').split(/\r?\n/);
+lines = lines.map(line => line.replace(/\s*\/\/.*$/, ''));
+const content = lines.join('\n');
+fs.writeFileSync(output, content);
+console.log(`Generated ${output}`);


### PR DESCRIPTION
## Summary
- create `strip_comments.js` helper to remove `//` comments from `pages.json`
- generate `pages_no_comment.json` to verify JSON validity

## Testing
- `node strip_comments.js && node -e "const fs=require('fs'); try{ JSON.parse(fs.readFileSync('pages_no_comment.json','utf8')); console.log('ok'); } catch(e){ console.error(e.message); }"`


------
https://chatgpt.com/codex/tasks/task_e_6857f8b6bb908327abadfceaa2c6b623