### PR TITLE
Fix SCSS math module import

### DIFF
--- a/tn_components/clock.vue
+++ b/tn_components/clock.vue
@@ -223,9 +223,10 @@
 </script>
 
 <style lang="scss" scoped>
-	$W: 140rpx;
-	$titleSize: 32rpx;
-	$signH: 80rpx;
+        @use "sass:math";
+        $W: 140rpx;
+        $titleSize: 32rpx;
+        $signH: 80rpx;
 	.b-card{
 		margin: 30rpx;
 		padding: 30rpx;


### PR DESCRIPTION
## Summary
- add `@use "sass:math"` to clock component styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858154f17448327b1e0df7c138e9dc1