### PR TITLE
Fix SCSS negative math.div usage

### DIFF
--- a/tn_components/clock.vue
+++ b/tn_components/clock.vue
@@ -223,9 +223,10 @@
 </script>
 
 <style lang="scss" scoped>
-	$W: 140rpx;
-	$titleSize: 32rpx;
-	$signH: 80rpx;
+        @use "sass:math";
+        $W: 140rpx;
+        $titleSize: 32rpx;
+        $signH: 80rpx;
 	.b-card{
 		margin: 30rpx;
 		padding: 30rpx;
@@ -309,7 +310,7 @@
 					position: absolute;
 					bottom: 0;
 					left: 50%;
-					margin-left: -math.div($W, 2);
+                                        margin-left: math.div(-$W, 2);
 					.footer-outer{
 						width: $W;
 						height: $W;


### PR DESCRIPTION
## Summary
- fix negative math.div syntax in `clock.vue`

## Testing
- `npm test` *(fails: Could not read package.json)*【50435a†L1-L14】
- `npm test` in `vite-app` *(fails: Missing script "test")*【12b0f7†L1-L10】
- `npm test` in `uview-ui` *(fails: no test specified)*【51a7a7†L1-L7】

------
https://chatgpt.com/codex/tasks/task_e_6858154f17448327b1e0df7c138e9dc1