### PR TITLE
Fix SCSS negative math.div usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ vite-app/
 
 All legacy UniApp pages and components are kept in the repository for future reference.
 
+## Troubleshooting
+
+- **Sass compilation errors** – The project relies on the `sass:math` module for
+  division operations. Ensure your environment uses **Dart Sass 1.33+**. Older
+  versions will report `There is no module with the namespace "math"`. If
+  updating is not possible, replace calls to `math.div` with the traditional `/`
+  operator (which will emit deprecation warnings).
+- **WeChat Developer Tools not launching** – Running `npm run dev:mp-weixin`
+  requires a local installation of the WeChat Developer Tools. If the CLI
+  reports `Fail to open IDE`, confirm the tool is installed and that no other
+  instance is already running. You can manually open the tool and import the
+  generated `dist/build/mp-weixin` directory.
+
 ## License
 
 This project is released under the MIT License.

--- a/tn_components/clock.vue
+++ b/tn_components/clock.vue
@@ -223,9 +223,10 @@
 </script>
 
 <style lang="scss" scoped>
-	$W: 140rpx;
-	$titleSize: 32rpx;
-	$signH: 80rpx;
+        @use "sass:math";
+        $W: 140rpx;
+        $titleSize: 32rpx;
+        $signH: 80rpx;
 	.b-card{
 		margin: 30rpx;
 		padding: 30rpx;
@@ -309,7 +310,7 @@
 					position: absolute;
 					bottom: 0;
 					left: 50%;
-					margin-left: -math.div($W, 2);
+                                        margin-left: math.div(-$W, 2);
 					.footer-outer{
 						width: $W;
 						height: $W;


### PR DESCRIPTION
## Summary
- fix negative math.div syntax in `clock.vue`
- add troubleshooting notes to README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test` in `vite-app` *(fails: Missing script "test")*
- `npm test` in `uview-ui` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858154f17448327b1e0df7c138e9dc1